### PR TITLE
Build image for multiple platforms in the same time

### DIFF
--- a/buildx.sh
+++ b/buildx.sh
@@ -1,5 +1,7 @@
+# Build image for multiple platforms and push to registry in the same time
+
 export POLICY=manylinux2014
-#export PLATFORM=aarch64
+# export PLATFORM=aarch64
 export BASEIMAGE=centos:7
 export DEVTOOLSET_ROOTPATH=/opt/rh/devtoolset-10/root
 export PREPEND_PATH=/opt/rh/devtoolset-10/root/usr/bin:

--- a/buildx.sh
+++ b/buildx.sh
@@ -1,0 +1,8 @@
+export POLICY=manylinux2014
+#export PLATFORM=aarch64
+export BASEIMAGE=centos:7
+export DEVTOOLSET_ROOTPATH=/opt/rh/devtoolset-10/root
+export PREPEND_PATH=/opt/rh/devtoolset-10/root/usr/bin:
+export LD_LIBRARY_PATH_ARG=/opt/rh/devtoolset-10/root/usr/lib64:/opt/rh/devtoolset-10/root/usr/lib:/opt/rh/devtoolset-10/root/usr/lib64/dyninst:/opt/rh/devtoolset-10/root/usr/lib/dyninst:/usr/local/lib64
+
+docker buildx build --platform linux/amd64,linux/arm64 --push --build-arg POLICY --build-arg BASEIMAGE --build-arg DEVTOOLSET_ROOTPATH --build-arg PREPEND_PATH --build-arg LD_LIBRARY_PATH_ARG -t registry.cn-hongkong.aliyuncs.com/graphscope/manylinux2014:2022-12-12 -f docker/Dockerfile docker/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,18 +1,30 @@
 # default to latest supported policy, x86_64
 ARG BASEIMAGE=amd64/debian:9
 ARG POLICY=manylinux_2_24
-ARG PLATFORM=$TARGETPLATFORM
+ARG PLATFORM=x86_64
 ARG DEVTOOLSET_ROOTPATH=
 ARG LD_LIBRARY_PATH_ARG=
 ARG PREPEND_PATH=
 
 FROM $BASEIMAGE AS runtime_base
 ARG POLICY
-ARG PLATFORM=$TARGETPLATFORM
+ARG PLATFORM
 ARG DEVTOOLSET_ROOTPATH
 ARG LD_LIBRARY_PATH_ARG
 ARG PREPEND_PATH
 LABEL maintainer="The ManyLinux project"
+
+# refer from https://github.com/BretFisher/multi-platform-docker-build
+ARG TARGETPLATFORM
+RUN case ${TARGETPLATFORM} in \
+         "linux/amd64")   PLATFORM=x86_64   ;; \
+         "linux/arm64")   PLATFORM=aarch64  ;; \
+         "linux/arm/v7")  PLATFORM=armv7l   ;; \
+         "linux/arm/v6")  PLATFORM=armv7l   ;; \
+         "linux/386")     PLATFORM=i686     ;; \
+         "linux/ppc64le") PLATFORM=ppc64le  ;; \
+         "inux/s390x")    PLATFORM=s390x    ;; \
+    esac
 
 ENV AUDITWHEEL_POLICY=${POLICY} AUDITWHEEL_ARCH=${PLATFORM} AUDITWHEEL_PLAT=${POLICY}_${PLATFORM}
 ENV LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8

--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -33,7 +33,10 @@ function fetch_source {
     if [ -f ${file} ]; then
         echo "${file} exists, skipping fetch"
     else
-        curl -fsSL -o ${file} ${url}/${file}
+        # Use sock5s proxy to download files incase download fails in normal cases
+        # `host.docker.internal` is the localhost of host machine from a container's perspective.
+        # See https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host
+        curl -fsSL -o ${file} ${url}/${file} || curl -x socks5h://host.docker.internal:13659 -fsSL -o ${file} ${url}/${file}
     fi
 }
 

--- a/docker/build_scripts/finalize.sh
+++ b/docker/build_scripts/finalize.sh
@@ -12,9 +12,9 @@ source $MY_DIR/build_utils.sh
 mkdir /tmp/patchelf-binary
 pushd /tmp/patchelf-binary
 case ${AUDITWHEEL_ARCH} in
-	x86_64) curl -L -o patchelf.tar.gz https://github.com/NixOS/patchelf/releases/download/0.14.5/patchelf-0.14.5-x86_64.tar.gz ;;
-	i686) curl -L -o patchelf.tar.gz https://github.com/NixOS/patchelf/releases/download/0.14.5/patchelf-0.14.5-i686.tar.gz ;;
-	aarch64) curl -L -o patchelf.tar.gz https://github.com/NixOS/patchelf/releases/download/0.14.5/patchelf-0.14.5-aarch64.tar.gz ;;
+	x86_64) curl -fsSL -o patchelf.tar.gz https://github.com/NixOS/patchelf/releases/download/0.14.5/patchelf-0.14.5-x86_64.tar.gz ;;
+	i686) curl -fsSL -o patchelf.tar.gz https://github.com/NixOS/patchelf/releases/download/0.14.5/patchelf-0.14.5-i686.tar.gz ;;
+	aarch64) curl -fsSL -o patchelf.tar.gz https://github.com/NixOS/patchelf/releases/download/0.14.5/patchelf-0.14.5-aarch64.tar.gz ;;
 	*) echo "Skip installing patchelf for ${AUDITWHEEL_ARCH}" ;;
 esac
 tar zxvf patchelf.tar.gz || true


### PR DESCRIPTION
`buildx.sh` would results in a single image tag contains variants for different architectures,
and when pulling, docker could automatically selects the image that matches your OS and architecture.

In this case, pulling `registry.cn-hongkong.aliyuncs.com/graphscope/manylinux2014:2022-12-12` on amd64 or arm64 machines will images in their architecture correspondingly.

